### PR TITLE
[syncthing-bin.spec] Allow for installing on SailfishOS < 4.2 by downgrading the compression for binaries from `zstd` to `xz`

### DIFF
--- a/rpm/syncthing-bin.spec
+++ b/rpm/syncthing-bin.spec
@@ -13,6 +13,8 @@ URL:		https://syncthing.net/
 %define i486_basename %{binname}-linux-386-v%{version}
 %define remote_url https://github.com/syncthing/%{binname}/releases/download/v%{version}/
 %define __os_install_post %{nil}
+# See https://forum.sailfishos.org/t/13153/23?u=olf :
+%define _binary_payload w2.xzdio
 
 %ifarch armv7hl
 	%define basenam %{arm_basename}


### PR DESCRIPTION
Reference: https://forum.sailfishos.org/t/13153/23?u=olf